### PR TITLE
Fix: Prevent crash when price is null and set input type to number for price

### DIFF
--- a/views/listings/edit.ejs
+++ b/views/listings/edit.ejs
@@ -45,7 +45,7 @@
                 <input
                   name="listing[price]"
                   value="<%= listing.price %>"
-                  text="number"
+                  type="number"
                   class="form-control"
                   required
                 />

--- a/views/listings/index.ejs
+++ b/views/listings/index.ejs
@@ -14,7 +14,7 @@
         <div class="card-body">
           <p class="card-text">
             <b><%= listing.title %></b> <br>
-            &#8377; <%= listing.price.toLocaleString("en-IN") %>/night
+            &#8377; <%= listing.price ? listing.price.toLocaleString("en-IN") : 'N/A' %>/night
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Description

This pull request includes two improvements to the listings feature:
1. **Prevent crash when price is null** : Updated `index.ejs` to use a ternary operator to handle null prices.
2. **Set input type to number for price** : Changed the input type for price to `number` to ensure valid numerical input.

## Changes Made

- Modified `index.ejs` to use a ternary operator for displaying the price.
- Updated the `Price` input field to have a type of `number`.

## Motivation

These changes improve the robustness of the application by:
- Preventing crashes when the price is null.
- Ensuring that the price input field only accepts numerical values.

## Related Issue

Fixes # (if applicable, link to any related issues here)

## Testing

- Manually tested both changes by adding listings with null prices and ensuring the application no longer crashes.
- Verified that the price input field only accepts numerical values.
